### PR TITLE
Reset Levers on incorrect order

### DIFF
--- a/TerrorConsole/Assets/_Main/Assets/Sprites/Animations/Lever/Lever.controller
+++ b/TerrorConsole/Assets/_Main/Assets/Sprites/Animations/Lever/Lever.controller
@@ -33,8 +33,8 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: ChangeState
+  - m_ConditionMode: 2
+    m_ConditionEvent: IsActive
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -1995004805268403450}
@@ -92,6 +92,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 9100000}
+  - m_Name: IsActive
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -141,7 +147,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: ChangeState
+    m_ConditionEvent: IsActive
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 3980332563475469935}

--- a/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/OrderLeverController.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/OrderLeverController.cs
@@ -7,13 +7,13 @@ namespace TerrorConsole
     public class OrderLeverController : MonoBehaviour
     {
         [SerializeField] private List<SwitchObject> levers;
-        
+
         [SerializeField] private List<string> _correctOrder;
         private List<string> _currentOrder = new List<string>();
-        
+
         [SerializeField] private UnityEvent OnOrderSuccessful;
         [SerializeField] private UnityEvent OnOrderUnsuccesful;
-            
+
         private void Start()
         {
             foreach (var lever in levers)
@@ -45,11 +45,22 @@ namespace TerrorConsole
                 if (_currentOrder[i] != _correctOrder[i])
                 {
                     OnOrderUnsuccesful?.Invoke();
+                    ResetAllLevers();
                     return;
                 }
             }
-            
+
             OnOrderSuccessful?.Invoke();
+        }
+
+        private void ResetAllLevers()
+        {
+            _currentOrder.Clear();
+
+            foreach (var lever in levers)
+            {
+                lever.ResetLever();
+            }
         }
     }
 }

--- a/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/SwitchLever.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/SwitchLever.cs
@@ -5,14 +5,15 @@ namespace TerrorConsole
     public class SwitchLever : SwitchObject
     {
         private bool _isPlayerColliding;
-        [SerializeField] Animator _animator;
+        [SerializeField] private Animator _animator;
+        [SerializeField] private string _boolParameter = "IsActive";
 
         private void OnCollisionEnter2D(Collision2D collision)
         {
             if (collision.gameObject.CompareTag("Player"))
             {
                 InputManager.Source.OnActivateButton1 += AlternateState;
-                TooltipsManager.Source.ShowSpriteTooltip(InputActionsInGame.Button1, "Interact",(Vector2)collision.transform.position+Vector2.up);
+                TooltipsManager.Source.ShowSpriteTooltip(InputActionsInGame.Button1, "Interact", (Vector2)collision.transform.position + Vector2.up);
             }
         }
 
@@ -28,7 +29,14 @@ namespace TerrorConsole
         protected override void AlternateState()
         {
             base.AlternateState();
-            _animator.SetTrigger("ChangeState");
+
+            _animator.SetBool(_boolParameter, _state);
+        }
+
+        public override void ResetLever()
+        {
+            base.ResetLever();
+            _animator.SetBool(_boolParameter, false);
         }
     }
 }

--- a/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/SwitchObject.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/Objects/Switchs/SwitchObject.cs
@@ -9,7 +9,7 @@ namespace TerrorConsole
         [SerializeField] private string _sfxKey;
         public UnityEvent<string> OnActivated;
         public UnityEvent<string> OnDeactivated;
-        
+
         protected bool _state;
 
         protected virtual void AlternateState()
@@ -36,6 +36,14 @@ namespace TerrorConsole
         {
             _state = false;
             OnDeactivated?.Invoke(_id);
+        }
+
+        public virtual void ResetLever()
+        {
+            if (_state)
+            {
+              Off();
+            }
         }
 
         public void PlayObjetcSFX()


### PR DESCRIPTION
I changed the animation parameter from trigger to setbool for more control on animations. When the player is resolving the puzzle gives feedback at incorrect order

https://github.com/user-attachments/assets/e114e677-c181-4146-8ff3-4a94945fe7ba

close #141