### PR TITLE
Last played level is not correctly saved

### DIFF
--- a/TerrorConsole/Assets/_Main/Scripts/Objects/Doors/TransitionDoors.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/Objects/Doors/TransitionDoors.cs
@@ -14,6 +14,7 @@ namespace TerrorConsole
         }
         public void LoadScene(string sceneName)
         {
+            SaveSystemManager.Source.SetCurrentScene(sceneName);
             ScreenTransitionManager.Source.TransitionToScene(sceneName);
         }
     }

--- a/TerrorConsole/Assets/_Main/Scripts/SaveSystem/ISaveSystemSource.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/SaveSystem/ISaveSystemSource.cs
@@ -11,6 +11,7 @@ namespace TerrorConsole
         ISaveGameData GetGameDataByIndex(int fileIndex);
 
         void SetInventory(List<ItemInfo> newInventory);
+        void SetCurrentScene(string currentScene);
         List<ItemInfo> GetInventory();
 
         void AddOrUpdateLevelEvent(int levelNumber, string eventName, bool eventState);

--- a/TerrorConsole/Assets/_Main/Scripts/SaveSystem/SaveSystemManager.cs
+++ b/TerrorConsole/Assets/_Main/Scripts/SaveSystem/SaveSystemManager.cs
@@ -94,7 +94,7 @@ namespace TerrorConsole
         {
             SaveGame(_loadedGame.GetGameIndex(), _loadedGame);
         }
-
+        
         public void SaveGame(int fileIndex, SaveGameData data)
         {
             string json = JsonUtility.ToJson(data);
@@ -130,6 +130,12 @@ namespace TerrorConsole
             SaveCurrentGame();
         }
 
+        public void SetCurrentScene(string currentScene)
+        {
+            _loadedGame.SetCurrentScene(currentScene);
+            SaveCurrentGame();
+        }
+        
         public List<ItemInfo> GetInventory()
         {
             return _loadedGame.Inventory;


### PR DESCRIPTION
Closes #159 

When the player advances to the next level via a door, it is correctly saved in the SaveSystemManager, it is shown correctly in the main menu and the continue button goes to the correct scene.

![image](https://github.com/user-attachments/assets/49ea25c5-e730-4994-bc80-6e712ec97384)
